### PR TITLE
fallout-ce: expose unwrapped binary

### DIFF
--- a/pkgs/games/fallout-ce/build.nix
+++ b/pkgs/games/fallout-ce/build.nix
@@ -41,7 +41,7 @@ let
       exit $fault;
     fi
 
-    exec @out@/libexec/${pname} "$@"
+    exec @out@/bin/${pname}-unwrapped "$@"
   '';
 in
 stdenv.mkDerivation {
@@ -62,7 +62,7 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    install -D ${pname} $out/libexec/${pname}
+    install -D ${pname} $out/bin/${pname}-unwrapped
     install -D ${launcher} $out/bin/${pname}
     substituteInPlace $out/bin/${pname} --subst-var out
 


### PR DESCRIPTION
Why hiding the unwrapped binary in $out/libexec ?
Exposing it allows someone who is unhappy about the wrapper to just use that or make his own wrapper.
It's just the wrapper.sh that I wanted to hide, not the unwrapped binary.

And this time I've built and tested it !